### PR TITLE
Creates a shared_mount field in hpc.json

### DIFF
--- a/configs/config.ts
+++ b/configs/config.ts
@@ -28,6 +28,7 @@ for (var i in rawHpc) {
       init_sbatch_options: [],
       description: "none",
       globus: undefined,
+      mount: {},
       slurm_input_rules: {},
     },
     JSON.parse(JSON.stringify(rawHpc[i]))

--- a/configs/container.example.json
+++ b/configs/container.example.json
@@ -1,218 +1,212 @@
 {
-    "python": {
-        "dockerfile": "",
-        "dockerhub": "",
-        "hpc_path": {
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/python.sif",
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/python.sif",
-            "bridges_community_gpu": "/jet/home/cybergis/image/python.sif",
-            "anvil_community": "/home/x-cybergis/simages/python.sif"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
+  "python": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/python.sif",
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/python.sif",
+      "bridges_community_gpu": "/jet/home/cybergis/image/python.sif",
+      "anvil_community": "/home/x-cybergis/simages/python.sif"
     },
-    "cybergisx-0.4": {
-        "dockerfile": "",
-        "dockerhub": "",
-        "hpc_path": {
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/cybergisx_0.4.simg",
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/cybergisx_0.4.simg",
-	    "bridges_community_gpu": "/jet/home/cybergis/image/cybergisx_0.4.simg",
-            "anvil_community": "/home/x-cybergis/simages/cybergisx_0.4.simg"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "cjw-eb": {
-        "dockerfile": "",
-        "dockerhub": "",
-        "hpc_path": {
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/cjw-eb.simg",
-            "bridges_community": "/jet/home/cybergis/image/cybergisx_0.4.simg",
-            "anvil_community": "/home/x-cybergis/simages/cjw-eb.simg"
-        },
-        "mount": {
-            "keeling_community": {
-                "/data/cigi/cybergisx-easybuild": "/data/cigi/cybergisx-easybuild"
-            },
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "mpich": {
-        "dockerfile": "",
-        "dockerhub": "",
-        "hpc_path": {
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/mpich34.simg",
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/mpich34.simg",
-            "anvil_community": "/home/x-cybergis/simages/mpich34.simg"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "summa-3.0.3": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/summa3_xenial.simg",
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/summa3_xenial.simg",
-             "anvil_community": "/home/x-cybergis/simages/summa3_xenial.simg"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "wrfhydro-5.x": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "keeling_community": "/data/keeling/a/cigi-gisolve/simages/wrfhydro_focal.simg",
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/wrfhydro_focal.simg",
-            "anvil_community": "/home/x-cybergis/simages/wrfhydro_focal.simg"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "datafusion": {
-        "dockerfile": "",
-        "dockerhub": "",
-        "hpc_path": {
-            "bridges_community_gpu": "/jet/home/cybergis/image/fusion_env_v1.sif"
-        },
-        "mount": {
-            "bridges_community_gpu": {
-                "/jet/home/cybergis/data/datafusion": "/datafusion"
-            }
-        }
-    },
-    "damfiminput-connector": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "expanse_community": "/home/cybergis/SUMMA_IMAGE/damfiminput-connector.sif",
-            "anvil_community": "/home/x-cybergis/simages/damfiminput-connector.sif"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-    },
-    "era5input-connector": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "anvil_community": "/home/x-cybergis/simages/era5input-connector.sif"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-
-    },
-    "subsetaorcforcingdata-processor": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "anvil_community": "/home/x-cybergis/simages/subsetaorcforcingdata-processor.sif"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-
-    },
-    "cuahsisubsetterinput-connector": {
-       "dockerfile": "",
-       "dockerhub": "",
-       "hpc_path": {
-            "anvil_community": "/home/x-cybergis/simages/cuahsisubsetterinput-connector.sif"
-        },
-       "mount": {
-            "anvil_community": {
-                "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-            },
-            "expanse_community": {
-                "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-            },
-            "keeling_community": {
-                "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-            }
-        }
-
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
     }
-
-
-
+  },
+  "cybergisx-0.4": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/cybergisx_0.4.simg",
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/cybergisx_0.4.simg",
+      "bridges_community_gpu": "/jet/home/cybergis/image/cybergisx_0.4.simg",
+      "anvil_community": "/home/x-cybergis/simages/cybergisx_0.4.simg"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "cjw-eb": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/cjw-eb.simg",
+      "bridges_community": "/jet/home/cybergis/image/cybergisx_0.4.simg",
+      "anvil_community": "/home/x-cybergis/simages/cjw-eb.simg"
+    },
+    "mount": {
+      "keeling_community": {
+        "/data/cigi/cybergisx-easybuild": "/data/cigi/cybergisx-easybuild"
+      },
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "mpich": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/mpich34.simg",
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/mpich34.simg",
+      "anvil_community": "/home/x-cybergis/simages/mpich34.simg"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "summa-3.0.3": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/summa3_xenial.simg",
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/summa3_xenial.simg",
+      "anvil_community": "/home/x-cybergis/simages/summa3_xenial.simg"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "wrfhydro-5.x": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/wrfhydro_focal.simg",
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/wrfhydro_focal.simg",
+      "anvil_community": "/home/x-cybergis/simages/wrfhydro_focal.simg"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "datafusion": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "bridges_community_gpu": "/jet/home/cybergis/image/fusion_env_v1.sif"
+    },
+    "mount": {
+      "bridges_community_gpu": {
+        "/jet/home/cybergis/data/datafusion": "/datafusion"
+      }
+    }
+  },
+  "damfiminput-connector": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "expanse_community": "/home/cybergis/SUMMA_IMAGE/damfiminput-connector.sif",
+      "anvil_community": "/home/x-cybergis/simages/damfiminput-connector.sif"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "era5input-connector": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "anvil_community": "/home/x-cybergis/simages/era5input-connector.sif"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "subsetaorcforcingdata-processor": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "anvil_community": "/home/x-cybergis/simages/subsetaorcforcingdata-processor.sif"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  },
+  "cuahsisubsetterinput-connector": {
+    "dockerfile": "",
+    "dockerhub": "",
+    "hpc_path": {
+      "anvil_community": "/home/x-cybergis/simages/cuahsisubsetterinput-connector.sif"
+    },
+    "mount": {
+      "anvil_community": {
+        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      },
+      "expanse_community": {
+        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
+      },
+      "keeling_community": {
+        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      }
+    }
+  }
 }

--- a/configs/container.example.json
+++ b/configs/container.example.json
@@ -9,15 +9,6 @@
       "anvil_community": "/home/x-cybergis/simages/python.sif"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "cybergisx-0.4": {
@@ -30,15 +21,6 @@
       "anvil_community": "/home/x-cybergis/simages/cybergisx_0.4.simg"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "cjw-eb": {
@@ -50,18 +32,6 @@
       "anvil_community": "/home/x-cybergis/simages/cjw-eb.simg"
     },
     "mount": {
-      "keeling_community": {
-        "/data/cigi/cybergisx-easybuild": "/data/cigi/cybergisx-easybuild"
-      },
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "mpich": {
@@ -73,16 +43,7 @@
       "anvil_community": "/home/x-cybergis/simages/mpich34.simg"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
-    }
+    } 
   },
   "summa-3.0.3": {
     "dockerfile": "",
@@ -93,16 +54,7 @@
       "anvil_community": "/home/x-cybergis/simages/summa3_xenial.simg"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
-    }
+    } 
   },
   "wrfhydro-5.x": {
     "dockerfile": "",
@@ -113,15 +65,6 @@
       "anvil_community": "/home/x-cybergis/simages/wrfhydro_focal.simg"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "datafusion": {
@@ -131,9 +74,6 @@
       "bridges_community_gpu": "/jet/home/cybergis/image/fusion_env_v1.sif"
     },
     "mount": {
-      "bridges_community_gpu": {
-        "/jet/home/cybergis/data/datafusion": "/datafusion"
-      }
     }
   },
   "damfiminput-connector": {
@@ -144,15 +84,6 @@
       "anvil_community": "/home/x-cybergis/simages/damfiminput-connector.sif"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "era5input-connector": {
@@ -162,15 +93,6 @@
       "anvil_community": "/home/x-cybergis/simages/era5input-connector.sif"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "subsetaorcforcingdata-processor": {
@@ -180,15 +102,6 @@
       "anvil_community": "/home/x-cybergis/simages/subsetaorcforcingdata-processor.sif"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
     }
   },
   "cuahsisubsetterinput-connector": {
@@ -198,15 +111,6 @@
       "anvil_community": "/home/x-cybergis/simages/cuahsisubsetterinput-connector.sif"
     },
     "mount": {
-      "anvil_community": {
-        "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
-      },
-      "expanse_community": {
-        "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
-      },
-      "keeling_community": {
-        "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
-      }
-    }
+    } 
   }
 }

--- a/configs/hpc.example.json
+++ b/configs/hpc.example.json
@@ -23,7 +23,7 @@
       "root_path": "/"
     },
     "mount": {
-      "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+      "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
     }
   },
   "expanse_community": {
@@ -46,7 +46,7 @@
       "root_path": "/home/cybergis/scratch_folder/"
     },
     "mount": {
-      "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+      "/expanse/lustre/projects/usu104/cybergis/compute": "/compute_shared"
     },
     "init_sbatch_script": [
       "module load DefaultModules",

--- a/configs/hpc.example.json
+++ b/configs/hpc.example.json
@@ -1,111 +1,112 @@
 {
-    "keeling_community": {
-        "ip": "keeling.earth.illinois.edu",
-        "port": 22,
-        "is_community_account": true,
-        "community_login": {
-            "user": "cigi-gisolve",
-            "use_local_key": false,
-            "external_key": {
-                "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
-                "passphrase": null
-            }
-        },
-        "root_path": "/data/keeling/a/cigi-gisolve/scratch",
-        "init_sbatch_script": [
-            "# module use /data/cigi/common/cigi-modules",
-            "module load gnu/openmpi-4.1.2-gnu-4.8.5"
-        ],
-        "job_pool_capacity": 10,
-        "globus": {
-            "identity": "apadmana@illinois.edu",
-            "endpoint": "a1fa3d20-123d-11ec-ba7d-138ac5bdb19f",
-            "root_path": "/"
-        }
+  "keeling_community": {
+    "ip": "keeling.earth.illinois.edu",
+    "port": 22,
+    "is_community_account": true,
+    "community_login": {
+      "user": "cigi-gisolve",
+      "use_local_key": false,
+      "external_key": {
+        "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
+        "passphrase": null
+      }
     },
-    "expanse_community": {
-        "ip": "login.expanse.sdsc.edu",
-        "port": 22,
-        "is_community_account": true,
-        "community_login": {
-            "user": "cybergis",
-            "use_local_key": false,
-            "external_key": {
-                "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
-                "passphrase": null
-            }
-        },
-        "root_path": "/home/cybergis/scratch_folder/",
-        "job_pool_capacity": 10,
-        "globus": {
-            "identity": "apadmana@illinois.edu",
-            "endpoint": "b256c034-1578-11eb-893e-0a5521ff3f4b",
-            "root_path": "/home/cybergis/scratch_folder/"
-        },
-        "init_sbatch_script": [
-            "module load DefaultModules",
-            "module load singularitypro/3.9"
-        ],
-        "init_sbatch_options": [
-            "#SBATCH --constraint=lustre",
-            "#SBATCH --partition=shared",
-            "#SBATCH --nodes=1",
-            "#SBATCH --account=TG-EAR190007"
-        ],
-        "xsede_job_log_credential": {
-            "xsederesourcename": "expanse.sdsc.xsede.org",
-            "apikey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-        }
+    "root_path": "/data/keeling/a/cigi-gisolve/scratch",
+    "init_sbatch_script": [
+      "# module use /data/cigi/common/cigi-modules",
+      "module load gnu/openmpi-4.1.2-gnu-4.8.5"
+    ],
+    "job_pool_capacity": 10,
+    "globus": {
+      "identity": "apadmana@illinois.edu",
+      "endpoint": "a1fa3d20-123d-11ec-ba7d-138ac5bdb19f",
+      "root_path": "/"
     },
-    "bridges_community_gpu": {
-        "ip": "bridges2.psc.edu",
-        "port": 22,
-        "is_community_account": true,
-        "community_login": {
-            "user": "cybergis",
-            "use_local_key": false,
-            "external_key": {
-                "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
-                "passphrase": null
-            }
-        },
-        "root_path": "/jet/home/cybergis/data",
-        "job_pool_capacity": 10,
-        "globus": {
-            "identity": "apadmana@illinois.edu",
-            "endpoint": "8e5f3a0a-542d-11eb-a45a-0e095b4c2e55",
-            "root_path": "/jet/home/cybergis/data"
-        },
-        "init_sbatch_options": [
-            "#SBATCH --partition=GPU-shared"
-        ]
-    },
-    "anvil_community": {
-        "ip": "anvil.rcac.purdue.edu",
-        "port": 22,
-        "is_community_account": true,
-        "community_login": {
-            "user": "x-cybergis",
-            "use_local_key": false,
-            "external_key": {
-                "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
-                "passphrase": null
-            }
-        },
-        "root_path": "/anvil/scratch/x-cybergis/compute/",
-        "job_pool_capacity": 10,
-        "globus": {
-            "identity": "apadmana@illinois.edu",
-            "endpoint": "4fb6aabc-a900-4ca1-ad62-b33fee950930",
-            "root_path": "/"
-        },
-        "init_sbatch_script": [
-            "module load gcc",
-            "module load openmpi"
-        ],
-        "init_sbatch_options": [
-            "#SBATCH --partition=shared",
-            "#SBATCH --nodes=1"
-        ]
+    "mount": {
+      "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
     }
+  },
+  "expanse_community": {
+    "ip": "login.expanse.sdsc.edu",
+    "port": 22,
+    "is_community_account": true,
+    "community_login": {
+      "user": "cybergis",
+      "use_local_key": false,
+      "external_key": {
+        "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
+        "passphrase": null
+      }
+    },
+    "root_path": "/home/cybergis/scratch_folder/",
+    "job_pool_capacity": 10,
+    "globus": {
+      "identity": "apadmana@illinois.edu",
+      "endpoint": "b256c034-1578-11eb-893e-0a5521ff3f4b",
+      "root_path": "/home/cybergis/scratch_folder/"
+    },
+    "mount": {
+      "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared"
+    },
+    "init_sbatch_script": [
+      "module load DefaultModules",
+      "module load singularitypro/3.9"
+    ],
+    "init_sbatch_options": [
+      "#SBATCH --constraint=lustre",
+      "#SBATCH --partition=shared",
+      "#SBATCH --nodes=1",
+      "#SBATCH --account=TG-EAR190007"
+    ],
+    "xsede_job_log_credential": {
+      "xsederesourcename": "expanse.sdsc.xsede.org",
+      "apikey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  },
+  "bridges_community_gpu": {
+    "ip": "bridges2.psc.edu",
+    "port": 22,
+    "is_community_account": true,
+    "community_login": {
+      "user": "cybergis",
+      "use_local_key": false,
+      "external_key": {
+        "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
+        "passphrase": null
+      }
+    },
+    "root_path": "/jet/home/cybergis/data",
+    "job_pool_capacity": 10,
+    "globus": {
+      "identity": "apadmana@illinois.edu",
+      "endpoint": "8e5f3a0a-542d-11eb-a45a-0e095b4c2e55",
+      "root_path": "/jet/home/cybergis/data"
+    },
+    "init_sbatch_options": ["#SBATCH --partition=GPU-shared"]
+  },
+  "anvil_community": {
+    "ip": "anvil.rcac.purdue.edu",
+    "port": 22,
+    "is_community_account": true,
+    "community_login": {
+      "user": "x-cybergis",
+      "use_local_key": false,
+      "external_key": {
+        "private_key_path": "/job_supervisor/keys/cigi-gisolve.key",
+        "passphrase": null
+      }
+    },
+    "root_path": "/anvil/scratch/x-cybergis/compute/",
+    "job_pool_capacity": 10,
+    "globus": {
+      "identity": "apadmana@illinois.edu",
+      "endpoint": "4fb6aabc-a900-4ca1-ad62-b33fee950930",
+      "root_path": "/"
+    },
+    "mount": {
+      "/anvil/projects/x-cis220065/x-cybergis/compute": "/compute_shared"
+    },
+    "init_sbatch_script": ["module load gcc", "module load openmpi"],
+    "init_sbatch_options": ["#SBATCH --partition=shared", "#SBATCH --nodes=1"]
+  }
 }

--- a/configs/jupyter-globus-map.example.json
+++ b/configs/jupyter-globus-map.example.json
@@ -1,33 +1,33 @@
 {
-    "cybergisx.cigi.illinois.edu": {
-        "comment": "original CyberGISX",
-        "endpoint": "418e684e-1260-11ec-ba7d-138ac5bdb19f",
-        "root_path": "/~/data/cigi/cybergis-jupyter/production_data/notebook_home_data/",
-        "container_home_path": "/home/jovyan/work/"
-    },
-    "hsdocs-dev.cigi.illinois.edu": {
-        "comment": "original CyberGISX dev",
-        "endpoint": "418e684e-1260-11ec-ba7d-138ac5bdb19f",
-        "root_path": "/~/data/cigi/cybergis-jupyter/production_data/notebook_home_data",
-        "container_home_path": "/home/jovyan/work/"
-    },
-    "js2-155-137.jetstream-cloud.org": {
-        "comment": "CJW-js2",
-        "endpoint": "d45b1832-f3f8-11ec-aede-6f7c2b57b05c",
-        "root_path": "/~/mnt/nfs_folder/notebook_home_data/",
-        "container_home_path": "/home/jovyan/work/"
-    },
-    "www.iguide.geoedf.org": {
-        "comment":"IGUIDE on js2 k8s",
-        "endpoint": "4ae398fe-17fc-11ed-8db7-9f359c660fbd",
-        "root_path": "/~/mnt/jupyter-data/",
-        "container_home_path": "/home/jovyan/",
-        "user_mapping": "iguide-mapping"
-    },
-    "cjw-swarm-master-dev.ear190007.projects.jetstream-cloud.org": {
-        "comment": "CJW-js2-dev",
-        "endpoint": "d45b1832-f3f8-11ec-aede-6f7c2b57b05c",
-        "root_path": "/~/mnt/nfs_folder/notebook_home_data/",
-        "container_home_path": "/home/jovyan/work/"
-    }
+  "cybergisx.cigi.illinois.edu": {
+    "comment": "original CyberGISX",
+    "endpoint": "418e684e-1260-11ec-ba7d-138ac5bdb19f",
+    "root_path": "/~/data/cigi/cybergis-jupyter/production_data/notebook_home_data/",
+    "container_home_path": "/home/jovyan/work/"
+  },
+  "hsdocs-dev.cigi.illinois.edu": {
+    "comment": "original CyberGISX dev",
+    "endpoint": "418e684e-1260-11ec-ba7d-138ac5bdb19f",
+    "root_path": "/~/data/cigi/cybergis-jupyter/production_data/notebook_home_data",
+    "container_home_path": "/home/jovyan/work/"
+  },
+  "js2-155-137.jetstream-cloud.org": {
+    "comment": "CJW-js2",
+    "endpoint": "d45b1832-f3f8-11ec-aede-6f7c2b57b05c",
+    "root_path": "/~/mnt/nfs_folder/notebook_home_data/",
+    "container_home_path": "/home/jovyan/work/"
+  },
+  "www.iguide.geoedf.org": {
+    "comment": "IGUIDE on js2 k8s",
+    "endpoint": "4ae398fe-17fc-11ed-8db7-9f359c660fbd",
+    "root_path": "/~/mnt/jupyter-data/",
+    "container_home_path": "/home/jovyan/",
+    "user_mapping": "iguide-mapping"
+  },
+  "cjw-swarm-master-dev.ear190007.projects.jetstream-cloud.org": {
+    "comment": "CJW-js2-dev",
+    "endpoint": "d45b1832-f3f8-11ec-aede-6f7c2b57b05c",
+    "root_path": "/~/mnt/nfs_folder/notebook_home_data/",
+    "container_home_path": "/home/jovyan/work/"
+  }
 }

--- a/configs/maintainer.example.json
+++ b/configs/maintainer.example.json
@@ -1,21 +1,21 @@
 {
-    "hello_world_singularity": {
-        "hpc": ["keeling_community"],
-        "default_hpc": "keeling_community",
-        "job_pool_capacity": 5,
-        "executable_folder": {
-            "from_user": false
-        },
-        "maintainer": "HelloWorldSingularityMaintainer"
+  "hello_world_singularity": {
+    "hpc": ["keeling_community"],
+    "default_hpc": "keeling_community",
+    "job_pool_capacity": 5,
+    "executable_folder": {
+      "from_user": false
     },
-    "community_contribution": {
-        "hpc": ["instant_hpc","keeling_community", "bridges_community"],
-        "default_hpc": "keeling_community",
-        "job_pool_capacity": 5,
-        "executable_folder": {
-            "from_user": true,
-            "allowed_protocol": "git"
-        },
-        "maintainer": "CommunityContributionMaintainer"
-    }
+    "maintainer": "HelloWorldSingularityMaintainer"
+  },
+  "community_contribution": {
+    "hpc": ["instant_hpc", "keeling_community", "bridges_community"],
+    "default_hpc": "keeling_community",
+    "job_pool_capacity": 5,
+    "executable_folder": {
+      "from_user": true,
+      "allowed_protocol": "git"
+    },
+    "maintainer": "CommunityContributionMaintainer"
+  }
 }

--- a/src/connectors/SingularityConnector.ts
+++ b/src/connectors/SingularityConnector.ts
@@ -1,6 +1,6 @@
 import SlurmConnector from "./SlurmConnector";
 import { slurm, executableManifest } from "../types";
-import { containerConfigMap } from "../../configs/config";
+import { containerConfigMap, hpcConfigMap } from "../../configs/config";
 
 class SingularityConnector extends SlurmConnector {
   /**
@@ -129,6 +129,14 @@ class SingularityConnector extends SlurmConnector {
     }
 
     if (manifest) {
+      var hpc = hpcConfigMap[this.hpcName];
+      if (hpc) {
+        if (hpc.mount) {
+          for (var i in hpc.mount){
+            this.volumeBinds[i] = hpc.mount[i];
+          }
+        }
+      }
       var container = containerConfigMap[manifest.container];
       if (container) {
         if (container.mount) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,9 @@ export interface hpcConfig {
     endpoint?: string;
     root_path?: string;
   };
+  mount: {
+    [keys: string]: string;
+  };
   slurm_input_rules?: slurmInputRules;
   slurm_global_cap: slurm;
   xsede_job_log_credential: XSEDEJobLogCredential;


### PR DESCRIPTION
## Features
- Implements shared mount field in hpc.json.
- Formats all of the jsons in `configs` to align with [VSCode formatting](https://www.w3schools.io/editor/vscode-format-code/).

## Motivation
Reduced the duplication for `mount` field in `container.example.json`. 

## Backward Compatibility
Mounts in `container.example.json` still get  override preference over the new mounts specified in `hpc.example.json`

## Test
Was successfully tested using a test job that does `ls && echo "echo hello world" > /compute_shared/hello.txt && cat /compute_shared/hello.txt`
 (https://github.com/mitkotak/compute_shared_mount_test)