### PR TITLE
update to GitUtil.ts to avoid crashes

### DIFF
--- a/src/lib/GitUtil.ts
+++ b/src/lib/GitUtil.ts
@@ -1,3 +1,4 @@
+import DB from "../DB";
 import FolderUtil from "./FolderUtil";
 import { Git } from "../models/Git";
 import { exec } from "child-process-async";
@@ -20,6 +21,17 @@ export default class GitUtil {
     return path.join(config.local_file_system.root_path, gitId);
   }
 
+  static async deleteAndPull(git: Git) {
+    const localPath = this.getLocalPath(git.id);
+    rimraf.sync(localPath);
+    await fs.promises.mkdir(localPath);
+    await exec(`cd ${localPath} && git clone ${git.address} ${localPath}`);
+    if (git.sha) {
+      // if a sha is specified, checkout that commit
+      await exec(`cd ${localPath} && git checkout ${git.sha}`);
+    };
+  }
+
   static async refreshGit(git: Git) {
     const localPath = this.getLocalPath(git.id);
     await FolderUtil.removeZip(localPath);
@@ -30,27 +42,55 @@ export default class GitUtil {
       await exec(`cd ${localPath} && git clone ${git.address} ${localPath}`);
     }
 
-    // update git repo before upload
-    if (git.sha) {
+    //check when last updated
+    var now = new Date();
+    const secsSinceUpdate = (now.getTime() - git.updatedAt.getTime()) / 1000.0;
+    if (secsSinceUpdate > 120) {
+      console.log(`${git.id} is stale, let's update...`);
+      // update git repo before upload
       try {
-        await exec(`cd ${localPath} && git checkout ${git.sha}`);
+        // try checking out the sha or pulling latest
+        if (git.sha) {
+          await exec(`cd ${localPath} && git checkout ${git.sha}`);
+        } else {
+          await exec(`cd ${localPath} && git pull`);
+        }
       } catch {
-        rimraf.sync(localPath);
-        await fs.promises.mkdir(localPath);
-        await exec(`cd ${localPath} && git clone ${git.address} ${localPath}`);
-        await exec(`cd ${localPath} && git checkout ${git.sha}`);
+        // if there is an error, delete and repull
+        await this.deleteAndPull(git);
       }
-    } else {
-      await exec(`cd ${localPath} && git pull`);
+      // call to update the updatedAt timestamp
+      now = new Date();
+      const db = new DB(false);
+      var connection = await db.connect();
+      await connection
+            .createQueryBuilder()
+            .update(Git)
+            .where("id = :id", { id: git.id })
+            .set({'updatedAt' : now})
+            .execute();
     }
+    else {
+      console.log(`${git.id} last updated ${secsSinceUpdate}s ago, skipping update`);
+    };
   }
 
   static async getExecutableManifest(git: Git) {
     const localPath = this.getLocalPath(git.id);
     const executableFolderPath = path.join(localPath, "manifest.json");
-    const rawExecutableManifest = (
-      await fs.promises.readFile(executableFolderPath)
-    ).toString();
+    let rawExecutableManifest;
+    try {
+      rawExecutableManifest = (
+        await fs.promises.readFile(executableFolderPath)
+      ).toString();
+    } catch (e) {
+      // delete, repull, and then read
+      console.log(`Encountered error with manifest: ${e}.\nDeleting and repulling`)
+      await this.deleteAndPull(git);
+      rawExecutableManifest = (
+        await fs.promises.readFile(executableFolderPath)
+      ).toString();
+    }
 
     const executableManifest: executableManifest = Object.assign(
       {


### PR DESCRIPTION
This PR attempts to resolve #67, #79, and a few other small issues with GitUtil like it panicking if the manifest.json gets deleted.

Main Changes:
--------------------
* Turned the "delete local repo and clone" code into it's own function `deleteAndPull`.
* Calculates the number of seconds since last update, only updating a repo every two minutes.
* The `if (git.sha)` code is now inside of the Try block so that errors from `git pull`/`git checkout` will both be caught by the catch block (which calls `deleteAndPull`).
* At the end of end of `refreshGit` we now update the database entry's `updatedAt` field to the current time (used for determining if the repo needs to be updated when new jobs are submitted).
* In `getExecutableManifest` rather than simply throwing an error if the manifest can't be read, we call `deleteAndPull` to delete the repo, clone it again, and then read the manifest.

I believe including the `if (git.sha)` code in the Try block will solve #67 and #79 will hopefully be solved by the "how long since updated" check, but we are waiting to hear back from the person who reported the bug to do extensive testing.