### PR TITLE
fix for git null bug (#88)

### DIFF
--- a/src/lib/GitUtil.ts
+++ b/src/lib/GitUtil.ts
@@ -44,7 +44,12 @@ export default class GitUtil {
 
     //check when last updated
     var now = new Date();
-    const secsSinceUpdate = (now.getTime() - git.updatedAt.getTime()) / 1000.0;
+    // set to a large number so that we update if the check fails
+    var secsSinceUpdate = 1000000;
+    try {
+        // check when last updated if you can. If updatedAt is null this throws error
+        secsSinceUpdate = (now.getTime() - git.updatedAt.getTime()) / 1000.0;
+    } catch {}
     if (secsSinceUpdate > 120) {
       console.log(`${git.id} is stale, let's update...`);
       // update git repo before upload


### PR DESCRIPTION
Quick fix for #88. 

Basically just set `secsSinceUpdate` to a large value and then in a try block try to check when it was last updated. If you get an error on checking `git.updatedAt.getTime()` (due to git.updatedAt being null) then it goes to an empty catch block and we assume the large value meaning that we perform an update.