### PR TITLE
CVMFS Container/cvmfs.out

### DIFF
--- a/configs/container.example.json
+++ b/configs/container.example.json
@@ -112,5 +112,14 @@
     },
     "mount": {
     } 
+  },
+  "cvmfs": {
+    "dockerfile": "",
+    "dockerhub": "https://hub.docker.com/repository/docker/cybergisx/compute-cvmfs",
+    "hpc_path": {
+      "keeling_community": "/data/keeling/a/cigi-gisolve/simages/cvmfs.sif"
+    },
+    "mount": {
+    }
   }
 }

--- a/configs/hpc.example.json
+++ b/configs/hpc.example.json
@@ -18,7 +18,7 @@
       "CYBERGIS_COMPUTE_BASE=$(pwd)",
       "source ~/.bashrc  # this adds the `singcvmfs` executable to the path",
       "cd $CYBERGIS_COMPUTE_BASE",
-      "export SINGCVMFS_REPOSITORIES=\"grid.cern.ch,cybergis.illinois.edu\"  # required for singcvmfs, specifies repositories",
+      "export SINGCVMFS_REPOSITORIES=\"cybergis.illinois.edu\"  # required for singcvmfs, specifies repositories",
       "export SINGCVMFS_CACHEDIR=$tmp_path",
       "export BASE=\"$(pwd)\"",
       "export tmp_path=\"/tmp/cvmfs-$(openssl rand -hex 12)\"",

--- a/configs/hpc.example.json
+++ b/configs/hpc.example.json
@@ -19,6 +19,7 @@
       "source ~/.bashrc  # this adds the `singcvmfs` executable to the path",
       "cd $CYBERGIS_COMPUTE_BASE",
       "export SINGCVMFS_REPOSITORIES=\"grid.cern.ch,cybergis.illinois.edu\"  # required for singcvmfs, specifies repositories",
+      "export SINGCVMFS_CACHEDIR=$tmp_path",
       "export BASE=\"$(pwd)\"",
       "export tmp_path=\"/tmp/cvmfs-$(openssl rand -hex 12)\"",
       "mkdir $tmp_path"

--- a/configs/kernel.example.json
+++ b/configs/kernel.example.json
@@ -13,15 +13,19 @@
 },
 "cybergisx/python3-0.9.0": {
   "env": [
+    "export CYBERGISCVMFSLOG=${result_folder}/cvmfs.out",
     "source /etc/profile.d/z00_lmod.sh",
-    "module --version",
+    "module --version >> $CYBERGISCVMFSLOG 2>&1",
+    "ls /cvmfs/cybergis.illinois.edu/software/easybuild/modules/all /cvmfs/cybergis.illinois.edu/software/metamodules >> $CYBERGISCVMFSLOG",
     "module use /cvmfs/cybergis.illinois.edu/software/easybuild/modules/all",
     "module use /cvmfs/cybergis.illinois.edu/software/metamodules",
     "module load cybergisx/0.8.0",
+    "ls /cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/bin /cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/share /cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/lib/python3.8/site-packages >> $CYBERGISCVMFSLOG",
     "alias python=/cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/bin/python",
     "alias python3=/cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/bin/python",
     "export PATH=\"/cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/bin:$PATH\"",
-    "export MY_PROJ_LIB=\"/cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/share/proj\""
+    "export MY_PROJ_LIB=\"/cvmfs/cybergis.illinois.edu/software/conda/cybergisx/python3-0.9.0/share/proj\"",
+    "python -c \"import pandas; import geopandas; import matplotlib\" >> $CYBERGISCVMFSLOG"
   ]
 },
 "cybergisx/geoai-0.8.0": {

--- a/src/connectors/SingularityConnector.ts
+++ b/src/connectors/SingularityConnector.ts
@@ -120,7 +120,7 @@ class SingularityConnector extends SlurmConnector {
           " "
         )} singcvmfs -s exec ${this._getVolumeBindCMD()} -cip ${containerPath} bash -c \"cd ${this.getContainerExecutableFolderPath()} && source kernel_init.sh && ${
           manifest.post_processing_stage
-        }\"`;
+        }\"\n\n`;
         cmd += `rm -r $tmp_path\n`;
       }
       else{

--- a/src/lib/GitUtil.ts
+++ b/src/lib/GitUtil.ts
@@ -44,7 +44,12 @@ export default class GitUtil {
 
     //check when last updated
     var now = new Date();
-    const secsSinceUpdate = (now.getTime() - git.updatedAt.getTime()) / 1000.0;
+    // set to a large number so that we update if the check fails
+    var secsSinceUpdate = 1000000;
+    try {
+        // check when last updated if you can. If updatedAt is null this throws error
+        secsSinceUpdate = (now.getTime() - git.updatedAt.getTime()) / 1000.0;
+    } catch {}
     if (secsSinceUpdate > 120) {
       console.log(`${git.id} is stale, let's update...`);
       // update git repo before upload


### PR DESCRIPTION
Patch for a few small problems we're having with singcvmfs:

* Adds `cvmfs` container to container.json and utilizes it in the SingularityConnector
* Removes grid.cern.ch from `SINGCVMFS_REPOSITORIES` (not supported by our proxies)
* Redirects kernel_init.sh outputs to cvmfs.out

Should be deployed on test.