### PR TITLE
allowing model devs to specify modules

### DIFF
--- a/src/connectors/SlurmConnector.ts
+++ b/src/connectors/SlurmConnector.ts
@@ -56,8 +56,7 @@ class SlurmConnector extends BaseConnector {
 
     let modules = "";
     if (config.modules) {
-      for (const module of config.modules)
-        modules += `module load ${module}\n`;
+      modules += `module load ${config.modules}\n`;
     }
 
     Helper.nullGuard(this.remote_result_folder_path);

--- a/src/connectors/SlurmConnector.ts
+++ b/src/connectors/SlurmConnector.ts
@@ -35,7 +35,7 @@ class SlurmConnector extends BaseConnector {
     for (const module of this.modules) {
       modules += `module load ${module}\n`;
     }
-    return modules
+    return modules;
   }
 
   /**
@@ -65,10 +65,9 @@ class SlurmConnector extends BaseConnector {
       config.partition = hpc.partition;
     }
 
-    let modules = "";
     if (config.modules) {
-      // modules += `module load ${config.modules}\n`;
-      this.registerModules(config.modules.split(/\s/))
+      // TODO: make this split more robust
+      this.registerModules(config.modules.split(/\s/));
     }
 
 

--- a/src/connectors/SlurmConnector.ts
+++ b/src/connectors/SlurmConnector.ts
@@ -19,12 +19,23 @@ class SlurmConnector extends BaseConnector {
   public isContainer = false;
 
   /**
-   * Registers all of the specified modules
+   * Registers all of the specified modules.
    *
    * @param {Array<string>} modules - Array of strings
    */
   registerModules(modules: string[]) {
     this.modules = this.modules.concat(modules);
+  }
+
+  /**
+   * Creates a string to import the this.modules modules.
+   */
+  getModuleLoadString() {
+    let modules = "\n";
+    for (const module of this.modules) {
+      modules += `module load ${module}\n`;
+    }
+    return modules
   }
 
   /**
@@ -56,8 +67,10 @@ class SlurmConnector extends BaseConnector {
 
     let modules = "";
     if (config.modules) {
-      modules += `module load ${config.modules}\n`;
+      // modules += `module load ${config.modules}\n`;
+      this.registerModules(config.modules.split(/\s/))
     }
+
 
     Helper.nullGuard(this.remote_result_folder_path);
     Helper.nullGuard(config.mail_type);
@@ -106,7 +119,7 @@ ${
     ? this.connectorConfig.init_sbatch_script.join("\n")
     : ""
 }
-${modules}
+${this.getModuleLoadString()}
 ${cmd}`;
   }
 

--- a/src/definitions/JobTypes.ts
+++ b/src/definitions/JobTypes.ts
@@ -13,6 +13,7 @@ export const slurm_configs = [
   "gpus_per_socket",
   "gpus_per_task",
   "partition",
+  "modules",
 ];
 export const slurm_integer_configs = [
   "num_of_node",
@@ -42,7 +43,7 @@ export const slurm_integer_none_unit_config = [
   "gpus_per_socket",
   "gpus_per_task",
 ];
-export const slurm_string_option_configs = ["partition"];
+export const slurm_string_option_configs = ["modules", "partition"];
 
 export interface integerRule {
   type?: "integer";
@@ -77,6 +78,7 @@ export interface slurmInputRules {
   gpus_per_socket?: integerRule;
   gpus_per_task?: integerRule;
   partition?: stringOptionRule;
+  modules?: stringOptionRule;
 }
 
 export interface rawAccessToken {
@@ -111,7 +113,7 @@ export interface slurm {
   allocation?: string;
   mail_type?: string[];
   mail_user?: string[];
-  modules?: string[];
+  modules?: string;
 }
 
 export interface executableManifest {


### PR DESCRIPTION
A bit clunky (stringOptionRule), but allows model developers to specify a single string of modules to load before running their code. Ex.:

```
{
    "name": "CyberGIS-ABM",
    "container": "lsabm.sif",
    "pre_processing_stage": "cd /becky/cybergisabm_compute/test && ./test_cases",
    "execution_stage": "ls",
    "post_processing_stage": "cp /becky/cybergisabm_compute/test/*.jpg $result_folder/",
    "slurm_input_rules": {
        "time": {
            "max": 30,
            "min": 20,
            "default_value": 20,
            "step": 1,
            "unit": "Minutes"
        },
        "modules": {
            "type": "string_option",
            "options": [
                "intel/19.0.5.281 mvapich2/2.3.6"
            ],
            "default_value": "intel/19.0.5.281 mvapich2/2.3.6"
        }
    },
    "require_upload_data": false,
    "supported_hpc": [
        "anvil_community"
    ],
    "default_hpc": "anvil_community"
}
```

Requires a version of SDK that includes modules in the UI.py, making a corresponding PR.