### PR TITLE
Downloading with FileStream

### DIFF
--- a/configs/container.example.json
+++ b/configs/container.example.json
@@ -221,6 +221,10 @@
             "keeling_community": "/data/keeling/a/cigi-gisolve/simages/pysal-access.simg"
     },
     "mount": {
+        "keeling_community": {
+          "/data/cigi/scratch/cigi-gisolve/compute_shared": "/compute_shared",
+          "/data/cigi/common/michels9/herop_access_data/": "/job/herop_access_data"
+        }
     }
   },
   "gearlab-r": {

--- a/configs/hpc.example.json
+++ b/configs/hpc.example.json
@@ -14,7 +14,7 @@
       "root_path": "/data/keeling/a/cigi-gisolve/scratch",
       "init_sbatch_script": [
         "# module use /data/cigi/common/cigi-modules",
-        "module load gnu/openmpi-4.1.2-gnu-4.8.5"
+        "module load mpi/openmpi-x86_64"
       ],
       "job_pool_capacity": 10,
       "globus": {

--- a/src/server/FolderRoutes.ts
+++ b/src/server/FolderRoutes.ts
@@ -190,10 +190,7 @@ folderRouter.put("/:folderId", authMiddleWare, async function (req, res) {
  * /folder/:folderId/download/globus-init:
  *  post:
  *      description: Posts a request to initiate a globus download of the specified folder (Authentication REQUIRED)
- *      responses:eferenceError: require is not defined in ES module scope, you can use import instead
-This file is being treated as an ES module because it has a '.js' file extension and '/job_supervisor/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
-    at file:///job_supervisor/production/src/server/FolderRoutes.js:2:12
-
+ *      responses:
  *          200:
  *              description: Globus download of the specific folder is successful
  *          402:
@@ -426,8 +423,6 @@ folderRouter.post(
 
     try {
       const downloadPath = path.join(localFileFolder, folderId + ".zip");
-      console.log("Just after download path")
-      console.log(downloadPath)
       const connector = await SSHConnector.build(hpc);
       
       if (!connector) {
@@ -435,7 +430,6 @@ folderRouter.post(
       }
       
       await connector.downloadFolderZip(hpcPath, downloadPath, true);
-      console.log("Just before res.download")
 
       // Check if the file exists
       fs.stat(downloadPath, (err, stats) => {

--- a/src/server/FolderRoutes.ts
+++ b/src/server/FolderRoutes.ts
@@ -1,6 +1,6 @@
 import express from "express";
-import fs from "fs";
 
+import fs from "fs";
 import * as path from "path";
 
 import {
@@ -433,23 +433,23 @@ folderRouter.post(
 
       // Check if the file exists
       fs.stat(downloadPath, (err, stats) => {
-          if (err || !stats.isFile()) {
-              return res.status(404).send('File not found');
-          }
+        if (err || !stats.isFile()) {
+          return res.status(404).send("File not found");
+        }
 
-          // Set headers for download
-          res.setHeader('Content-Disposition', `attachment; filename="result.zip"`);
-          res.setHeader('Content-Type', 'application/octet-stream'); // Or specific MIME type
-          res.setHeader('Content-Length', stats.size); // Optional, can be handled by chunked encoding
+        // Set headers for download
+        res.setHeader("Content-Disposition", "attachment; filename=\"result.zip\"");
+        res.setHeader("Content-Type", "application/octet-stream"); // Or specific MIME type
+        res.setHeader("Content-Length", stats.size); // Optional, can be handled by chunked encoding
 
-          // Create a read stream and pipe it to the response
-          const fileStream = fs.createReadStream(downloadPath);
-          fileStream.pipe(res);
+        // Create a read stream and pipe it to the response
+        const fileStream = fs.createReadStream(downloadPath);
+        fileStream.pipe(res);
 
-          fileStream.on('error', (streamErr) => {
-              console.error('Stream error:', streamErr);
-              res.status(500).end('Server error during file transfer');
-          });
+        fileStream.on("error", (streamErr) => {
+          console.error("Stream error:", streamErr);
+          res.status(500).end("Server error during file transfer");
+        });
       });
       // res.download(downloadPath);
     } catch (err) {

--- a/src/server/FolderRoutes.ts
+++ b/src/server/FolderRoutes.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import fs from "fs";
 
 import * as path from "path";
 
@@ -189,7 +190,10 @@ folderRouter.put("/:folderId", authMiddleWare, async function (req, res) {
  * /folder/:folderId/download/globus-init:
  *  post:
  *      description: Posts a request to initiate a globus download of the specified folder (Authentication REQUIRED)
- *      responses:
+ *      responses:eferenceError: require is not defined in ES module scope, you can use import instead
+This file is being treated as an ES module because it has a '.js' file extension and '/job_supervisor/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
+    at file:///job_supervisor/production/src/server/FolderRoutes.js:2:12
+
  *          200:
  *              description: Globus download of the specific folder is successful
  *          402:
@@ -422,6 +426,8 @@ folderRouter.post(
 
     try {
       const downloadPath = path.join(localFileFolder, folderId + ".zip");
+      console.log("Just after download path")
+      console.log(downloadPath)
       const connector = await SSHConnector.build(hpc);
       
       if (!connector) {
@@ -429,7 +435,29 @@ folderRouter.post(
       }
       
       await connector.downloadFolderZip(hpcPath, downloadPath, true);
-      res.download(downloadPath);
+      console.log("Just before res.download")
+
+      // Check if the file exists
+      fs.stat(downloadPath, (err, stats) => {
+          if (err || !stats.isFile()) {
+              return res.status(404).send('File not found');
+          }
+
+          // Set headers for download
+          res.setHeader('Content-Disposition', `attachment; filename="result.zip"`);
+          res.setHeader('Content-Type', 'application/octet-stream'); // Or specific MIME type
+          res.setHeader('Content-Length', stats.size); // Optional, can be handled by chunked encoding
+
+          // Create a read stream and pipe it to the response
+          const fileStream = fs.createReadStream(downloadPath);
+          fileStream.pipe(res);
+
+          fileStream.on('error', (streamErr) => {
+              console.error('Stream error:', streamErr);
+              res.status(500).end('Server error during file transfer');
+          });
+      });
+      // res.download(downloadPath);
     } catch (err) {
       res
         .status(403)


### PR DESCRIPTION
Encountered an issue with the web browser app where some downloads were taking abnormally long time. I think move the download to a filestream has lessened the issue. Note: there is still some lag while waiting for the file to be copied from the HPC to the server, we can work to address that in the future.

* Changes browser download to use filestream
* Updates the keeling HPC config to use the new module (from Keeling9) for MPI to remove that warning
* Adds data directory to the container configs for the pysal-access container.